### PR TITLE
Add cardinality and contains method for range sets

### DIFF
--- a/spans/__init__.py
+++ b/spans/__init__.py
@@ -11,7 +11,7 @@ together.
 
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __all__ = [
 	"intrange",
 	"floatrange",

--- a/spans/settypes.py
+++ b/spans/settypes.py
@@ -79,6 +79,21 @@ class rangeset(object):
     def __lt__(self, other):
         return self._list < other._list
 
+    def __len__(self):
+        """
+        Returns the cardinality of the set which is 0 for the empty set or else
+        the length of the list used internally.
+
+            >>> len(intrangeset([]))
+            0
+            >>> len(intrangeset([intrange(1,5)]))
+            1
+            >>> len(intrangeset([intrange(1,5),intrange(10,20)]))
+            2
+
+        """
+        return len(self._list) if self else 0
+
     def __invert__(self):
         """
         Returns an inverted version of this set. The inverted set contains no

--- a/spans/settypes.py
+++ b/spans/settypes.py
@@ -94,6 +94,27 @@ class rangeset(object):
         """
         return len(self._list) if self else 0
 
+    def __contains__(self, elem):
+        """
+        Return True if one range within the set contains elem, which may be
+        either a range of the same type or a scalar of the same type as the
+        ranges within the set.
+
+            >>> 3 in intrangeset([intrange(1, 5)])
+            True
+            >>> 7 in intrangeset([intrange(1, 5), intrange(10, 20)])
+            False
+            >>> intrange(2, 3) in intrangeset([intrange(1, 5)])
+            True
+            >>> intrange(4, 6) in intrangeset([intrange(1, 5), intrange(8, 9)])
+            False
+
+        """
+        for r in self._list:
+            if r.contains(elem) is True:
+                return True
+        return False
+
     def __invert__(self):
         """
         Returns an inverted version of this set. The inverted set contains no


### PR DESCRIPTION
Sets should have a cardinality, i.e. the number of elements. The Python set types have this and I would expect everything that looks like a set to have a cardinality.

In addition, it should be possible to check if a element is within a set of ranges by simply checking if it is in one of the members.