### PR TITLE
Fix exception when comparing sets to other objects

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,9 +9,9 @@ Version 0.2.0
 Released on 22nd December, 2015
 
 - Added :meth:`~spans.settypes.rangeset.__len__` to range sets
-  (`Michael Krate <https://github.com/der-michik>`_)
+  (`Michael Krahe <https://github.com/der-michik>`_)
 - Added :meth:`~spans.settypes.rangeset.contains` to range sets
-  (`Michael Krate <https://github.com/der-michik>`_)
+  (`Michael Krahe <https://github.com/der-michik>`_)
 - Added `Sphinx <http://sphinx-doc.org/>`_ style doc strings to all methods
 - Added proper Sphinx documentation
 - Added unit tests for uncovered parts, mostly error checking

--- a/spans/settypes.py
+++ b/spans/settypes.py
@@ -158,9 +158,13 @@ class rangeset(object):
         return iter(self._list)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self._list == other._list
 
     def __lt__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self._list < other._list
 
     def __len__(self):

--- a/spans/tests/test_settypes.py
+++ b/spans/tests/test_settypes.py
@@ -123,6 +123,8 @@ class TestIntRangeSet(TestCase):
             intrangeset([range_a, range_b]) == intrangeset([range_a, range_b]))
         self.assertFalse(
             intrangeset([range_a, range_b]) == intrangeset([range_a]))
+        self.assertFalse(
+            intrangeset([range_a]) == "foo")
 
     def test_less_than(self):
         range_a = intrange(1, 5)
@@ -134,6 +136,8 @@ class TestIntRangeSet(TestCase):
             intrangeset([range_a, range_b]) < intrangeset([range_b]))
         self.assertFalse(
             intrangeset([range_a, range_b]) <= intrangeset([range_a]))
+        self.assertFalse(
+            intrangeset([range_a]) == "foo")
 
     def test_greater_than(self):
         range_a = intrange(1, 5)


### PR DESCRIPTION
Comparing a rangeset to an object which does not have a `_list` attribute raises an `AttributeError`. In this case, `__eq__` should instead return `NotImplemented` as it already does for ranges. I also added this to the tests.