### PR TITLE
Fix python syntax issue in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Using ``daterange.from_month`` we can get range representing January in the year
 
     >>> month = daterange.from_month(2000, 1)
     >>> month
-    daterange([datetime.date(2000, 1, 1),datetime.date(2000, 2, 1)))
+    daterange([datetime.date(2000, 1, 1),datetime.date(2000, 2, 1)])
 
 Now we can calculate the ranges for the weeks where the first and last day of
 month are
@@ -55,16 +55,16 @@ month are
     >>> start_week = daterange.from_date(month.lower, period="week")
     >>> end_week = daterange.from_date(month.last, period="week")
     >>> start_week
-    daterange([datetime.date(1999, 12, 27),datetime.date(2000, 1, 3)))
+    daterange([datetime.date(1999, 12, 27),datetime.date(2000, 1, 3)])
     >>> end_week
-    daterange([datetime.date(2000, 1, 31),datetime.date(2000, 2, 7)))
+    daterange([datetime.date(2000, 1, 31),datetime.date(2000, 2, 7)])
 
 Using a union we can express the calendar view.
 
 .. code-block:: python
 
     >>> start_week.union(month).union(end_week)
-    daterange([datetime.date(1999, 12, 27),datetime.date(2000, 2, 7)))
+    daterange([datetime.date(1999, 12, 27),datetime.date(2000, 2, 7)])
 
 Do you want to know more? Head over to the
 `documentation <http://spans.readthedocs.org/en/latest/>`_.


### PR DESCRIPTION
In the examples with lists, the closing `]` was instead a closing `)`